### PR TITLE
fix: Allow configuring of previously ignored discovered devices via ZIP upload

### DIFF
--- a/custom_components/homeconnect_ws/config_flow.py
+++ b/custom_components/homeconnect_ws/config_flow.py
@@ -203,9 +203,11 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
         appliance_options: list[SelectOptionDict] = []
         try:
             for appliance_id, appliance_info in self.appliances.items():
-                if not self.hass.config_entries.async_entry_for_domain_unique_id(
+                existing_entry = self.hass.config_entries.async_entry_for_domain_unique_id(
                     self.handler, appliance_id
-                ):
+                )
+
+                if not existing_entry or existing_entry.source == "ignore":
                     brand = appliance_info["info"]["brand"]
                     appliance_type = appliance_info["info"]["type"]
                     vib = appliance_info["info"]["vib"]

--- a/custom_components/homeconnect_ws/config_flow.py
+++ b/custom_components/homeconnect_ws/config_flow.py
@@ -14,7 +14,7 @@ import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from aiohttp import ClientConnectionError, ClientConnectorSSLError
 from homeassistant.components.file_upload import process_uploaded_file
-from homeassistant.config_entries import ConfigFlow
+from homeassistant.config_entries import SOURCE_IGNORE, ConfigFlow
 from homeassistant.const import (
     CONF_DESCRIPTION,
     CONF_DEVICE,
@@ -207,7 +207,7 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
                     self.handler, appliance_id
                 )
 
-                if not existing_entry or existing_entry.source == "ignore":
+                if not existing_entry or existing_entry.source == SOURCE_IGNORE:
                     brand = appliance_info["info"]["brand"]
                     appliance_type = appliance_info["info"]["type"]
                     vib = appliance_info["info"]["vib"]


### PR DESCRIPTION
After having installed this integration a while back and not having used it, because there was some issue (don't ask me what) in the setup process, today I tried to return to it and faced a roadblock

Specifically, I got this message

![image](https://github.com/user-attachments/assets/ac1464c0-9639-4a16-b39d-488f6395f6bb)

and was _very_ confused, because there was nothing set up.

After some debugging I learned, that I must've at some point clicked on "ignore" for the discovered device.
This then _also_ created a config entry. Just one that is "ignored" in nature.

Hence, the logic that would prevent double-configuration failed and showed me this error message

For reference, this is how the ignored config entry looks like on disk

```json
{
    "created_at": "2025-05-09T15:55:41.596316+00:00",
    "data": {},
    "disabled_by": null,
    "discovery_keys": {
        "zeroconf": [
            {
                "domain": "zeroconf",
                "key": [
                    "_homeconnect._tcp.local.",
                    "Dishwasher SIEMENS SN45ZS49CE._homeconnect._tcp.local."
                ],
                "version": 1
            }
        ]
    },
    "domain": "homeconnect_ws",
    "entry_id": "xxx",
    "minor_version": 1,
    "modified_at": "2025-05-09T15:55:41.596324+00:00",
    "options": {},
    "pref_disable_new_entities": false,
    "pref_disable_polling": false,
    "source": "ignore",
    "subentries": [],
    "title": "Home Connect Local",
    "unique_id": "xxx",
    "version": 1
}
```