### PR TITLE
feat: Better zeroconf discovery title

### DIFF
--- a/custom_components/homeconnect_ws/config_flow.py
+++ b/custom_components/homeconnect_ws/config_flow.py
@@ -341,6 +341,13 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
             self.data[CONF_NAME] = (
                 f"{discovery_info.properties['brand']} {discovery_info.properties['type']}"
             )
+
+            self.context.update(
+                {
+                    "title_placeholders": {"name": discovery_info.name.split(".")[0]},
+                }
+            )
+
             return await self.async_step_upload()
         except KeyError:
             return self.async_abort(reason="invalid_discovery_info")


### PR DESCRIPTION
As it works now, when the integration discovers a new device, it spawns a found device like this:

![image](https://github.com/user-attachments/assets/15ed9ca8-fb71-4c56-a888-1e78ca832c06)

That's not very helpful when you have multiple ones though.
I had to randomly try to upload zip files for each of the ones I got until it started working.

With this PR, it will look like this:

![image](https://github.com/user-attachments/assets/dfbf613e-9538-42d1-a8e0-29f948086575)


Logic has been taken from how the official shelly integration does it:
https://github.com/home-assistant/core/blob/45c0a19a6897cfdd95ce633b94a121802153833d/homeassistant/components/shelly/config_flow.py#L310-L315