### PR TITLE
Minor fixes DE

### DIFF
--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -810,7 +810,7 @@
         "name": "Anzahl Kaffee-Milch-Spezialitäten"
       },
       "sensor_count_frothy_milk": {
-        "name": "Anzahl Milchschau"
+        "name": "Anzahl Milchschaum"
       },
       "sensor_count_hot_milk": {
         "name": "Anzahl Milchgetränke"

--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -1,4 +1,4 @@
-{
+bu{
   "config": {
     "step": {
       "upload": {
@@ -630,7 +630,7 @@
         "name": "Verzögerte Abschaltung"
       },
       "sensor_power_state": {
-        "name": "Betriebszustand",
+        "name": "Status",
         "state": {
           "mainsoff": "Strom getrennt",
           "off": "Aus",
@@ -799,6 +799,30 @@
       },
       "sensor_wifi_signal_strength": {
         "name": "WLAN Signalstärke"
+      },
+      "sensor_count_ristretto_espresso": {
+        "name": "Anzahl Ristretto"
+      },
+      "sensor_count_coffee": {
+        "name": "Anzahl Kaffeegetränke"
+      },
+      "sensor_count_coffee_milk": {
+        "name": "Anzahl Kaffee-Milch-Spezialitäten"
+      },
+      "sensor_count_frothy_milk": {
+        "name": "Anzahl Milchschau"
+      },
+      "sensor_count_hot_milk": {
+        "name": "Anzahl Milchgetränke"
+      },
+      "sensor_count_hot_water": {
+        "name": "Menge Heißwasser"
+      },
+      "sensor_count_hot_water_cups": {
+        "name": "Anzahl Heißwasser"
+      },
+      "sensor_count_powder_coffee": {
+        "name": "Anzahl Pulverkaffee"
       }
     },
     "select": {
@@ -1582,6 +1606,9 @@
       },
       "button_start_program": {
         "name": "Start"
+      },
+      "button_resume_program": {
+        "name": "Fortsetzen"
       }
     },
     "number": {

--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -1,4 +1,4 @@
-bu{
+{
   "config": {
     "step": {
       "upload": {


### PR DESCRIPTION
1. both `power state` and `operation state` mapped to `Betriebszustand` in DE resulting in confusion and weird entity names (`sensor.betriebszustand` and `sensor.betriebszustand_2`)
2. DE translations for new coffee counters
3. DE translation for `resume` button