### PR TITLE
Unify okay

### DIFF
--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -165,21 +165,21 @@
         "name": "Kondensatbehälter Füllstand",
         "state": {
           "on": "Voll",
-          "off": "Ok"
+          "off": "OK"
         }
       },
       "binary_sensor_machinecarereminder": {
         "name": "Maschinenreinigung",
         "state": {
           "on": "Wartung nötig",
-          "off": "Ok"
+          "off": "OK"
         }
       },
       "binary_sensor_lint_filter_full": {
         "name": "Flusenfilter",
         "state": {
           "on": "Filter reinigen",
-          "off": "Ok"
+          "off": "OK"
         }
       },
       "binary_sensor_maintenance_reminder": {
@@ -600,7 +600,7 @@
       "sensor_drip_tray": {
         "name": "Auffangschale",
         "state": {
-          "ok": "Ok",
+          "ok": "OK",
           "not_inserted": "Nicht eingesetzt",
           "full": "Voll"
         }
@@ -786,7 +786,7 @@
       "sensor_oven_water_tank": {
         "name": "Wassertank{group_name}",
         "state": {
-          "ok": "Ok",
+          "ok": "OK",
           "empty": "Leer",
           "unplugged": "Ausgesteckt"
         }

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -189,14 +189,14 @@
         "name": "Condensate Container",
         "state": {
           "on": "Full",
-          "off": "Ok"
+          "off": "OK"
         }
       },
       "binary_sensor_lint_filter_full": {
         "name": "Lint Filter",
         "state": {
           "on": "Full",
-          "off": "Ok"
+          "off": "OK"
         }
       },
       "binary_sensor_maintenance_reminder": {
@@ -367,7 +367,7 @@
       "sensor_drip_tray": {
         "name": "Drip tray",
         "state": {
-          "ok": "Ok",
+          "ok": "OK",
           "not_inserted": "Not Inserted",
           "full": "Full"
         }
@@ -553,7 +553,7 @@
       "sensor_oven_water_tank": {
         "name": "Water Tank{group_name}",
         "state": {
-          "ok": "Ok",
+          "ok": "OK",
           "empty": "Empty",
           "unplugged": "Unplugged"
         }
@@ -1317,4 +1317,5 @@
       }
     }
   }
+
 }

--- a/custom_components/homeconnect_ws/translations/it.json
+++ b/custom_components/homeconnect_ws/translations/it.json
@@ -165,14 +165,14 @@
         "name": "Contenitore condensa",
         "state": {
           "on": "Pieno",
-          "off": "Ok"
+          "off": "OK"
         }
       },
       "binary_sensor_lint_filter_full": {
         "name": "Filtro",
         "state": {
           "on": "Pieno",
-          "off": "Ok"
+          "off": "OK"
         }
       },
       "binary_sensor_maintenance_reminder": {
@@ -314,7 +314,7 @@
       "sensor_drip_tray": {
         "name": "Gocciolatoio",
         "state": {
-          "ok": "Ok",
+          "ok": "OK",
           "not_inserted": "Non inserito",
           "full": "Pieno"
         }
@@ -500,7 +500,7 @@
       "sensor_oven_water_tank": {
         "name": "Serbatoio acqua{group_name}",
         "state": {
-          "ok": "Ok",
+          "ok": "OK",
           "empty": "Vuoto",
           "unplugged": "Scollegato"
         }
@@ -1035,4 +1035,5 @@
       }
     }
   }
+
 }


### PR DESCRIPTION
Non-translated binary sensors output "OK" while translated sensors output "Ok". This should be unified to use the Home Assistant way (also because the only correct ways are "OK" or "Okay" - but not "Ok").