### PR TITLE
Coffeemaker: allow short-/long-term stats for counters

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/consumer_products.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/consumer_products.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.number import NumberDeviceClass, NumberMode
 from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import SensorStateClass
 from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import UnitOfVolume
 
@@ -147,61 +148,73 @@ CONSUMER_PRODUCTS_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             key="sensor_countdown_calc_n_clean",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCountdownCalcNClean",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.MEASUREMENT,
         ),
         HCSensorEntityDescription(
             key="sensor_countdown_cleaning",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCountdownCleaning",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.MEASUREMENT,
         ),
         HCSensorEntityDescription(
             key="sensor_countdown_descaling",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCountdownDescaling",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.MEASUREMENT,
         ),
         HCSensorEntityDescription(
             key="sensor_countdown_water_filter",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCountdownWaterfilter",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.MEASUREMENT,
         ),
         HCSensorEntityDescription(
             key="sensor_count_ristretto_espresso",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCounterRistrettoEspresso",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         HCSensorEntityDescription(
             key="sensor_count_coffee",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCounterCoffee",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         HCSensorEntityDescription(
             key="sensor_count_coffee_milk",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCounterCoffeeAndMilk",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         HCSensorEntityDescription(
             key="sensor_count_frothy_milk",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCounterFrothyMilk",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         HCSensorEntityDescription(
             key="sensor_count_hot_milk",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCounterHotMilk",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         HCSensorEntityDescription(
             key="sensor_count_hot_water",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCounterHotWater",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         HCSensorEntityDescription(
             key="sensor_count_hot_water_cups",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCounterHotWaterCups",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         HCSensorEntityDescription(
             key="sensor_count_powder_coffee",
             entity="ConsumerProducts.CoffeeMaker.Status.BeverageCounterPowderCoffee",
             entity_registry_enabled_default=False,
+            state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         HCSensorEntityDescription(
             key="sensor_coffeemaker_process_phase",


### PR DESCRIPTION
Counters (number of beverages) and countdowns (cups until cleaning required etc.) were missing a `StateClass` and were therefore never tracked in short- nor long-term statistics.