### PR TITLE
Update Dutch translations in nl.json for dishwashers

### DIFF
--- a/custom_components/homeconnect_ws/translations/nl.json
+++ b/custom_components/homeconnect_ws/translations/nl.json
@@ -81,6 +81,12 @@
       },
       "binary_sensor_bean_container_empty": {
         "name": "Bonenreservoir leeg"
+      },
+      "binary_remote_start_allowed": {
+        "name": "Bediening op afstand toegestaan"
+      },
+      "binary_sensor_program_aborted": {
+        "name": "Programma afgebroken"
       }
     },
     "sensor": {
@@ -103,7 +109,7 @@
         "name": "Programmafase"
       },
       "sensor_active_program": {
-        "name": "Actief Programma",
+        "name": "Actief programma",
         "state": {
           "dishcare_dishwasher_program_intensiv70": "Intensief 70",
           "dishcare_dishwasher_program_auto2": "Auto 45-65",
@@ -172,7 +178,15 @@
       },
       "sensor_delayed_shutoff_time": {
         "name": "Vertraagde uitschakeling"
-      }
+      },
+      "sensor_power_state": {
+        "name": "Stroomstatus",
+        "state": {
+          "mainsoff": "Netspanning uit",
+          "off": "Uit",
+          "on": "Aan",
+          "standby": "Standby"
+        }
     },
     "select": {
       "select_drying_assistant_all_programs": {


### PR DESCRIPTION
This PR improves Dutch translations for the dishwashers. I just added a Siemens dishwasher in and was frustrated by parts of the entities not being translated properly. For now just entities, I might also go and translate some values.