### PR TITLE
Added lamp brightness control for DRC99PS20

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/cooking.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/cooking.py
@@ -257,7 +257,10 @@ def generate_hood_light(appliance: HomeAppliance) -> HCFanEntityDescription:
             color_temperature_entity="Cooking.Hood.Setting.ColorTemperaturePercent",
         )
 
-    if "Cooking.Hood.Setting.LightingBrightness" in appliance.entities:
+    if (
+        "Cooking.Hood.Setting.LightingBrightness" in appliance.entities
+        or "Cooking.Common.Setting.LightingBrightness" in appliance.entities
+    ):
         return HCLightEntityDescription(
             key="light_cooking_lighting",
             entity="Cooking.Common.Setting.Lighting",


### PR DESCRIPTION
Added entity name identifying brightness control in DRC99PS20, partially addressing https://github.com/chris-mc1/homeconnect_local_hass/issues/218