### PR TITLE
Fix ValueError when adding Siemens ovens with non-numeric group keys

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/cooking.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/cooking.py
@@ -30,13 +30,18 @@ if TYPE_CHECKING:
     from homeconnect_websocket import HomeAppliance
 
 
+def _extract_group_id(group_key: str) -> int:
+    """Extract numeric ID from group key, handling formats like '001.RemainingProgramTime'."""
+    return int(group_key.split(".")[0])
+
+
 def generate_oven_status(appliance: HomeAppliance) -> EntityDescriptions:
     """Get Oven status descriptions."""
     pattern = re.compile(r"^Cooking\.Oven\.Status\.Cavity\.(\d+)\..*$")
     groups = get_groups_from_regex(appliance, pattern)
     descriptions = EntityDescriptions(event_sensor=[], sensor=[])
     for group in groups:
-        group_name = f" {int(group[0])}"
+        group_name = f" {_extract_group_id(group[0])}"
         if len(groups) == 1:
             group_name = ""
 
@@ -80,7 +85,7 @@ def generate_oven_event(appliance: HomeAppliance) -> EntityDescriptions:
     groups = get_groups_from_regex(appliance, pattern)
     descriptions = EntityDescriptions(binary_sensor=[])
     for group in groups:
-        group_name = f" {int(group[0])}"
+        group_name = f" {_extract_group_id(group[0])}"
         if len(groups) == 1:
             group_name = ""
 
@@ -107,7 +112,7 @@ def generate_oven_settings(appliance: HomeAppliance) -> HCFanEntityDescription:
     groups = get_groups_from_regex(appliance, pattern)
     descriptions = EntityDescriptions(number=[])
     for group in groups:
-        group_name = f" {int(group[0])}"
+        group_name = f" {_extract_group_id(group[0])}"
 
         # AlarmClock
         entity = f"Cooking.Oven.Setting.Cavity.{group[0]}.AlarmClock"
@@ -148,7 +153,7 @@ def generate_hob_zones(appliance: HomeAppliance) -> HCFanEntityDescription:
     groups = get_groups_from_regex(appliance, pattern)
     descriptions = EntityDescriptions(sensor=[])
     for group in groups:
-        group_name = f" {int(group[0])}"
+        group_name = f" {_extract_group_id(group[0])}"
 
         # State
         entity = f"Cooking.Hob.Status.Zone.{group[0]}.State"


### PR DESCRIPTION
## Summary

Some Siemens oven models return entity group keys in the format `001.RemainingProgramTime` instead of just `001`. This caused a `ValueError` when attempting to convert the group key to an integer:

```
ValueError: invalid literal for int() with base 10: '001.RemainingProgramTime'
```

## Changes

- Added `_extract_group_id()` helper function that extracts only the numeric prefix before the first dot
- Updated all four affected functions to use this helper:
  - `generate_oven_status()`
  - `generate_oven_event()`
  - `generate_oven_settings()`
  - `generate_hob_zones()`

## Backwards Compatibility

The fix is backwards compatible - for purely numeric keys like `001`, `split(".")[0]` returns the original value.

## Testing

Tested on the following Siemens studioLine iQ700 ovens:
- Siemens Steam Oven CS936GCB1
- Siemens Oven HB974GLB1

Both ovens now set up successfully after applying this patch.

Fixes #277