### PR TITLE
Update cooking.py - Fix ValueError when parsing oven status key

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/cooking.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/cooking.py
@@ -36,7 +36,10 @@ def generate_oven_status(appliance: HomeAppliance) -> EntityDescriptions:
     groups = get_groups_from_regex(appliance, pattern)
     descriptions = EntityDescriptions(event_sensor=[], sensor=[])
     for group in groups:
-        group_name = f" {int(group[0])}"
+        try:
+            group_name = f" {int(group[0].split('.')[0])}"
+        except ValueError:
+            group_name = f" {group[0]}"        
         if len(groups) == 1:
             group_name = ""
 


### PR DESCRIPTION
Fixes "ValueError: invalid literal for int() with base 10: '001.RemainingProgramTime'" for Siemens oven CM776GKB1 and maybe other models too.

Some appliances expose status keys like:
001.RemainingProgramTime

The code tried to parse the full string as an int:
int(group[0])

This causes:
ValueError: invalid literal for int() with base 10

This PR splits the key and converts only the numeric prefix:
int(group[0].split('.')[0])