### PR TITLE
fix: parenthesize except clauses in config_flow

### DIFF
--- a/custom_components/homeconnect_ws/config_flow.py
+++ b/custom_components/homeconnect_ws/config_flow.py
@@ -191,7 +191,7 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
                     reason="profile_file_parser_error",
                     description_placeholders={"error": exc.args[0]},
                 )
-            except KeyError, ValueError:
+            except (KeyError, ValueError):
                 return self.async_abort(reason="invalid_profile_file")
 
             if not self.errors:
@@ -352,7 +352,7 @@ class HomeConnectConfigFlow(ConfigFlow, domain=DOMAIN):
             self.data[CONF_NAME] = f"{appliance_info['brand']} {appliance_info['type']}"
 
             self._set_encryption_keys(appliance_info)
-        except KeyError, ValueError:
+        except (KeyError, ValueError):
             return self.async_abort(reason="invalid_profile_file")
 
         return await self.async_step_test_connection()

--- a/custom_components/homeconnect_ws/coordinator.py
+++ b/custom_components/homeconnect_ws/coordinator.py
@@ -88,7 +88,7 @@ class HomeConnectCoordinator(DataUpdateCoordinator):
                     self.connected = True  # FIX
                     self.async_set_updated_data(None)  # FIX
                     return
-            except ConnectionFailedError, HCHandshakeError:
+            except (ConnectionFailedError, HCHandshakeError):
                 await self.appliance.close()
                 msg = f"Can't connect to {self.config_entry.data[CONF_HOST]}, retrying"
                 if first_failure:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,6 +1,6 @@
 # The contents of this file is based on https://github.com/home-assistant/core/blob/dev/pyproject.toml
 
-target-version = "py314"
+target-version = "py313"
 line-length = 100
 
 [lint]


### PR DESCRIPTION
`config_flow.py` has two `except KeyError, ValueError:` clauses left over from Python 2 syntax, which raise `SyntaxError` on import under Python 3 and prevent the integration from loading. Wrapping the exception types in parentheses restores the intended catch-multiple-types behaviour. Closes #375.