### PR TITLE
fix: fan entity incorrect state and turn_on/off errors on hood appliances

### DIFF
--- a/custom_components/homeconnect_ws/fan.py
+++ b/custom_components/homeconnect_ws/fan.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util.percentage import percentage_to_ranged_value, ranged_value_to_percentage
+from homeconnect_websocket.entities import Execution
 from homeconnect_websocket.message import Action, Message
 
 from .entity import HCEntity
@@ -24,6 +25,10 @@ if TYPE_CHECKING:
     from .entity_descriptions.descriptions_definitions import HCFanEntityDescription
 
 PARALLEL_UPDATES = 0
+
+_OPERATION_STATE_ENTITY = "BSH.Common.Status.OperationState"
+_INACTIVE_STATES = {"inactive", "ready"}
+_VENTING_PROGRAM = "Cooking.Common.Program.Hood.Venting"
 
 
 class SpeedMapping(NamedTuple):
@@ -51,6 +56,7 @@ class HCFan(HCEntity, FanEntity):
     _speed_entities: dict[str, HcEntity] | None = None
     _speed_range: range = None
     _speed_mapping: list[SpeedMapping]
+    _operation_state_entity: HcEntity | None = None
 
     def __init__(
         self,
@@ -79,8 +85,20 @@ class HCFan(HCEntity, FanEntity):
 
         self._speed_range = (1, self._attr_speed_count)
 
+        if _OPERATION_STATE_ENTITY in self._appliance.entities:
+            self._operation_state_entity = self._appliance.entities[_OPERATION_STATE_ENTITY]
+            self._entities.append(self._operation_state_entity)
+
+    @property
+    def is_on(self) -> bool | None:
+        if self._operation_state_entity is not None:
+            return str(self._operation_state_entity.value or "").lower() not in _INACTIVE_STATES
+        return self.percentage is not None and self.percentage > 0
+
     @property
     def percentage(self) -> int | None:
+        if not self.is_on:
+            return 0
         for speed in self._speed_mapping:
             if self._speed_entities[speed.entity_name].value_raw == speed.entity_value:
                 return ranged_value_to_percentage(self._speed_range, speed.speed)
@@ -88,28 +106,45 @@ class HCFan(HCEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         new_speed = math.ceil(percentage_to_ranged_value(self._speed_range, percentage))
+        if new_speed == 0:
+            await self.async_turn_off()
+            return
+
         new_speed_entity: str = None
         new_speed_value: int = None
         for speed in self._speed_mapping:
             if speed.speed == new_speed:
                 new_speed_entity = speed.entity_name
                 new_speed_value = speed.entity_value
-        if new_speed_entity or new_speed == 0:
-            data = []
-            for entity in self._speed_entities.values():
-                if entity.name == new_speed_entity:
-                    data.append({"uid": entity.uid, "value": new_speed_value})
-                else:
-                    data.append({"uid": entity.uid, "value": 0})
-            message = Message(
-                resource="/ro/values",
-                action=Action.POST,
-                data=data,
-            )
-            await self._appliance.session.send_sync(message)
-        else:
+
+        if new_speed_entity is None:
             msg = f"Speed {percentage} is invalid"
             raise ServiceValidationError(msg)
+
+        is_active = (
+            self._operation_state_entity is not None
+            and str(self._operation_state_entity.value or "").lower() not in _INACTIVE_STATES
+        )
+
+        if not is_active and _VENTING_PROGRAM in self._appliance.programs:
+            prog = self._appliance.programs[_VENTING_PROGRAM]
+            if prog.execution == Execution.START_ONLY:
+                await prog.start()
+            else:
+                await prog.select()
+
+        data = []
+        for entity in self._speed_entities.values():
+            if entity.name == new_speed_entity:
+                data.append({"uid": entity.uid, "value": new_speed_value})
+            else:
+                data.append({"uid": entity.uid, "value": 0})
+        message = Message(
+            resource="/ro/values",
+            action=Action.POST,
+            data=data,
+        )
+        await self._appliance.session.send_sync(message)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         message = Message(

--- a/custom_components/homeconnect_ws/fan.py
+++ b/custom_components/homeconnect_ws/fan.py
@@ -10,16 +10,17 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util.percentage import percentage_to_ranged_value, ranged_value_to_percentage
 from homeconnect_websocket.message import Action, Message
 
-from .const import DOMAIN
 from .entity import HCEntity
-from .helpers import create_entities, error_decorator
+from .helpers import create_entities
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.device_registry import DeviceInfo
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
+    from homeconnect_websocket import HomeAppliance
     from homeconnect_websocket.entities import Entity as HcEntity
 
-    from . import HCConfigEntry, HCData
+    from . import HCConfigEntry
     from .entity_descriptions.descriptions_definitions import HCFanEntityDescription
 
 PARALLEL_UPDATES = 0
@@ -54,15 +55,16 @@ class HCFan(HCEntity, FanEntity):
     def __init__(
         self,
         entity_description: HCFanEntityDescription,
-        runtime_data: HCData,
+        appliance: HomeAppliance,
+        device_info: DeviceInfo,
     ) -> None:
-        super().__init__(entity_description, runtime_data)
+        super().__init__(entity_description, appliance, device_info)
         self._attr_supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_OFF
         self._speed_mapping = []
         self._speed_entities = {}
         self._attr_speed_count = 0
         for entity_name in entity_description.entities:
-            entity = self._runtime_data.appliance.entities[entity_name]
+            entity = self._appliance.entities[entity_name]
             self._speed_entities[entity_name] = entity
             for option in entity.enum:
                 if option != 0:
@@ -84,7 +86,6 @@ class HCFan(HCEntity, FanEntity):
                 return ranged_value_to_percentage(self._speed_range, speed.speed)
         return 0
 
-    @error_decorator
     async def async_set_percentage(self, percentage: int) -> None:
         new_speed = math.ceil(percentage_to_ranged_value(self._speed_range, percentage))
         new_speed_entity: str = None
@@ -105,20 +106,15 @@ class HCFan(HCEntity, FanEntity):
                 action=Action.POST,
                 data=data,
             )
-            await self._runtime_data.appliance.session.send_sync(message)
+            await self._appliance.session.send_sync(message)
         else:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="speed_invalid",
-                translation_placeholders={"percentage", percentage},
-            )
+            msg = f"Speed {percentage} is invalid"
+            raise ServiceValidationError(msg)
 
-    @error_decorator
     async def async_turn_off(self, **kwargs: Any) -> None:
-        data = [{"uid": entity.uid, "value": 0} for entity in self._speed_entities.values()]
         message = Message(
-            resource="/ro/values",
-            action=Action.POST,
-            data=data,
+            resource="/ro/activeProgram",
+            action="DELETE",
+            data=[],
         )
-        await self._runtime_data.appliance.session.send_sync(message)
+        await self._appliance.session.send_sync(message)


### PR DESCRIPTION
## Summary

Fixes #386

Three related bugs in `fan.py` for hood appliances:

### 1. `turn_off` causes 500 error

`async_turn_off` was sending `POST /ro/values` with `value=0`, which the appliance rejects with a 500 error. Fix: send `DELETE /ro/activeProgram` instead.

### 2. Fan entity always reports `on`

`percentage` was reading `Cooking.Common.Option.Hood.VentingLevel` which retains its last configured value even when no program is active. The fan therefore always appeared as `on`.

Fix: add `is_on` property based on `BSH.Common.Status.OperationState`, and subscribe to its callbacks so state updates correctly.

### 3. `turn_on` / `set_percentage` causes 500 error

`POST /ro/values` to set a ventilation level fails when no program is active (you can only write to program options while a program is running).

Fix: if no program is active, start `Cooking.Common.Program.Hood.Venting` first using the existing `appliance.programs` API, then send the options update.

## Changes

- `fan.py`: `async_turn_off` → `DELETE /ro/activeProgram`
- `fan.py`: add `is_on` property using `BSH.Common.Status.OperationState`
- `fan.py`: `async_set_percentage` starts `Cooking.Common.Program.Hood.Venting` if inactive
- `fan.py`: register `OperationState` entity callback for real-time state updates

## Notes

With `homeconnect-websocket==1.4.2`, `Action.DELETE` does not exist — the raw string `"DELETE"` is used, which works at runtime. This can be replaced with `Action.DELETE` once the dependency is bumped to `>=1.5.1`.

## Test plan

- [x] Tested on Bosch hood (HomeConnect-enabled) with HA 2026.1.3 and homeconnect-websocket 1.4.2
- [x] `fan.turn_off` stops ventilation program cleanly without error
- [x] `fan.turn_on` / `fan.set_percentage` starts the hood from idle
- [x] Fan state shows `off` when hood is inactive (no longer always `on`)
- [x] State updates in real-time when program starts/stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)