### PR TITLE
Hood start only programs

### DIFF
--- a/custom_components/homeconnect_ws/select.py
+++ b/custom_components/homeconnect_ws/select.py
@@ -159,4 +159,6 @@ class HCProgram(HCSelect):
         if selected_program.execution in (Execution.SELECT_ONLY, Execution.SELECT_AND_START):
             await selected_program.select()
         elif selected_program.execution == Execution.START_ONLY:
-            await selected_program.start()
+            # Avoid sending uninitialized option shadow values for start-only programs.
+            # The appliance can use program defaults when options are omitted.
+            await selected_program.start(override_options=True)

--- a/custom_components/homeconnect_ws/select.py
+++ b/custom_components/homeconnect_ws/select.py
@@ -5,19 +5,22 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from homeassistant.components.select import SelectEntity
-from homeconnect_websocket.entities import Execution
+from homeconnect_websocket.entities import Access, Execution
 
 from .entity import HCEntity
-from .helpers import create_entities, error_decorator
+from .helpers import create_entities, entity_is_available, error_decorator
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
-    from homeconnect_websocket.entities import SelectedProgram
+    from homeconnect_websocket.entities import ActiveProgram, Program, SelectedProgram
 
     from . import HCConfigEntry, HCData
     from .entity_descriptions.descriptions_definitions import HCSelectEntityDescription
 PARALLEL_UPDATES = 0
+
+_ACTIVE_PROGRAM_ACCESS = (Access.READ_WRITE, Access.WRITE_ONLY)
+_SELECTED_PROGRAM_SUFFIX = ".SelectedProgram"
 
 
 async def async_setup_entry(
@@ -84,6 +87,7 @@ class HCProgram(HCSelect):
     """Program select Entity."""
 
     _entity: SelectedProgram
+    _active_program_entity: ActiveProgram | None = None
 
     def __init__(
         self,
@@ -93,17 +97,60 @@ class HCProgram(HCSelect):
         super().__init__(entity_description, runtime_data)
         self._programs = entity_description.mapping
         self._rev_programs = {value: key for key, value in self._programs.items()}
+        if (
+            entity_description.entity
+            and entity_description.entity.endswith(_SELECTED_PROGRAM_SUFFIX)
+        ):
+            active_program_entity = (
+                f"{entity_description.entity.removesuffix(_SELECTED_PROGRAM_SUFFIX)}"
+                ".ActiveProgram"
+            )
+            self._active_program_entity = runtime_data.appliance.entities.get(
+                active_program_entity
+            )
+            if self._active_program_entity:
+                self._entities.append(self._active_program_entity)
 
     @property
     def options(self) -> list[str] | None:
         return list(self._programs.values())
 
     @property
-    def current_option(self) -> list[str] | None:
-        if self._runtime_data.appliance.selected_program:
-            if self._runtime_data.appliance.selected_program.name in self._programs:
-                return self._programs[self._runtime_data.appliance.selected_program.name]
-            return self._runtime_data.appliance.selected_program.name
+    def available(self) -> bool:
+        if super().available:
+            return True
+        conn = (
+            self._runtime_data.coordinator.connected
+            or self._runtime_data.appliance.session.connected
+        )
+        if not conn or self._active_program_entity is None:
+            return False
+        return entity_is_available(
+            self._active_program_entity, _ACTIVE_PROGRAM_ACCESS
+        ) and self._programs_are_start_only()
+
+    def _programs_are_start_only(self) -> bool:
+        programs: list[Program | None] = [
+            self._runtime_data.appliance.programs.get(program)
+            for program in self._programs
+        ]
+        return bool(programs) and all(
+            program is not None
+            and program.available is not False
+            and program.execution == Execution.START_ONLY
+            for program in programs
+        )
+
+    @property
+    def current_option(self) -> str | None:
+        current_program = self._runtime_data.appliance.selected_program
+        if current_program is None and self._active_program_entity is not None:
+            current_program = self._runtime_data.appliance.active_program
+
+        if current_program:
+            if current_program.name in self._programs:
+                return self._programs[current_program.name]
+            return current_program.name
         return None
 
     @error_decorator

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -230,10 +230,7 @@ async def test_start_only_program_available_with_read_only_selected_program(
         Message(
             resource="/ro/activeProgram",
             action=Action.POST,
-            data={
-                "program": 501,
-                "options": [{"uid": 401, "value": None}, {"uid": 402, "value": None}],
-            },
+            data={"program": 501, "options": []},
         )
     )
 
@@ -284,9 +281,6 @@ async def test_select_program(
         Message(
             resource="/ro/activeProgram",
             action=Action.POST,
-            data={
-                "program": 502,
-                "options": [{"uid": 401, "value": None}, {"uid": 402, "value": None}],
-            },
+            data={"program": 502, "options": []},
         )
     )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -11,6 +11,7 @@ from homeassistant.components.select import (
 )
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, STATE_UNKNOWN
+from homeconnect_websocket.entities import Access, Execution
 from homeconnect_websocket.message import Action, Message
 
 from . import setup_config_entry
@@ -183,6 +184,58 @@ async def test_update_program(
 
     state = hass.states.get(entity_id)
     assert state.state == "Named Favorite"
+
+
+async def test_update_program_from_active_program(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,  # noqa: ARG001
+) -> None:
+    """Test updating program select entity from the active program."""
+    entity_id = "select.fake_brand_homeappliance_selectedprogram"
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+    await mock_appliance.entities["Test.ActiveProgram"].update({"value": 501})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == "test_program_program2"
+
+
+async def test_start_only_program_available_with_read_only_selected_program(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,  # noqa: ARG001
+) -> None:
+    """Test selecting start-only programs when SelectedProgram is read-only."""
+    entity_id = "select.fake_brand_homeappliance_selectedprogram"
+    await mock_appliance.entities["Test.SelectedProgram"].update({"access": Access.READ})
+    for program in mock_appliance.programs.values():
+        await program.update({"execution": Execution.START_ONLY})
+    assert await setup_config_entry(hass, MOCK_CONFIG_DATA)
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNKNOWN
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_OPTION: "test_program_program2",
+        },
+        blocking=True,
+    )
+
+    mock_appliance.session.send_sync.assert_awaited_once_with(
+        Message(
+            resource="/ro/activeProgram",
+            action=Action.POST,
+            data={
+                "program": 501,
+                "options": [{"uid": 401, "value": None}, {"uid": 402, "value": None}],
+            },
+        )
+    )
 
 
 async def test_select_program(


### PR DESCRIPTION
## Summary

Fix program selection for appliances where `BSH.Common.Root.SelectedProgram` is read-only but programs are exposed as `Execution.START_ONLY`.

Some hood appliances, including Neff `I94CBS8W0/03`, expose hood programs such as Automatic, Venting, Interval, and DelayedShutOff as start-only programs. In this case the selected-program select entity was created but stayed unavailable because `SelectedProgram` is not writable, even though `ActiveProgram` can start the programs.

## Changes

- Allow the program select to remain available when all mapped programs are `START_ONLY` and `ActiveProgram` is writable.
- Use `ActiveProgram` as a fallback for current program state.
- Start `START_ONLY` programs without sending uninitialized option shadow values.
- Add tests for read-only `SelectedProgram` with start-only programs.

## Tested

Tested on Neff hood `I94CBS8W0/03`, firmware `2.17.1.13549`.

Verified from a fresh Home Assistant restart that these programs work without manually turning the hood on first:

- Automatic
- Venting
- Interval
- DelayedShutOff