### PR TITLE
Add Machine Care Reminder sensor for dishwasher

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/dishcare.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/dishcare.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.sensor import (
     SensorDeviceClass,
+    SensorStateClass,
 )
 from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import EntityCategory
@@ -274,6 +275,13 @@ DISHCARE_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             entity="Dishcare.Dishwasher.Status.ProgramPhase",
             device_class=SensorDeviceClass.ENUM,
             has_state_translation=True,
+        ),
+        HCSensorEntityDescription(
+            key="sensor_machine_care_reminder",
+            entity="Dishcare.Dishwasher.Status.MachineCareReminder.RemainingProgramRuns",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            native_unit_of_measurement="cycles",
+            state_class=SensorStateClass.MEASUREMENT,
         ),
     ],
     "switch": [

--- a/custom_components/homeconnect_ws/translations/de.json
+++ b/custom_components/homeconnect_ws/translations/de.json
@@ -414,7 +414,7 @@
       "binary_sensor_oven_alarm_clock_elapsed": {
         "name": "Alarm abgelaufen{group_name}"
       },
-	  "binary_sensor_alarm_clock_elapsed": {
+      "binary_sensor_alarm_clock_elapsed": {
         "name": "Alarm abgelaufen"
       }
     },
@@ -1138,6 +1138,9 @@
       },
       "sensor_count_powder_coffee": {
         "name": "Anzahl Pulverkaffee"
+      },
+      "sensor_machine_care_reminder": {
+        "name": "Maschinenpflege Erinnerung"
       },
       "sensor_countdown_calc_n_clean": {
         "name": "calc'nClean notwendig"

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -970,6 +970,9 @@
       "sensor_count_powder_coffee": {
         "name": "Powder Coffee count"
       },
+      "sensor_machine_care_reminder": {
+        "name": "Machine Care Reminder"
+      },
       "sensor_countdown_calc_n_clean": {
         "name": "calc'nClean required"
       },
@@ -1871,11 +1874,11 @@
       "select_chiller_common_preset": {
         "name": "Chiller preset",
         "state": {
-          "meatfish": "29°F \uD83D\uDCA7 (Meat/Fish)",
-          "fruit": "32°F \uD83D\uDCA7 (Fruit)",
-          "vegetables": "32°F \uD83D\uDCA7\uD83D\uDCA7 (Vegetables)",
-          "beverages": "34°F \uD83D\uDCA7 (Beverages)",
-          "snacks": "40°F \uD83D\uDCA7 (Snacks/Misc.)",
+          "meatfish": "29°F 💧 (Meat/Fish)",
+          "fruit": "32°F 💧 (Fruit)",
+          "vegetables": "32°F 💧💧 (Vegetables)",
+          "beverages": "34°F 💧 (Beverages)",
+          "snacks": "40°F 💧 (Snacks/Misc.)",
           "custom": "Custom"
         }
       },

--- a/custom_components/homeconnect_ws/translations/it.json
+++ b/custom_components/homeconnect_ws/translations/it.json
@@ -708,6 +708,9 @@
       "sensor_oven_current_temperature": {
         "name": "Temperatura attuale{group_name}"
       },
+      "sensor_machine_care_reminder": {
+        "name": "Promemoria cura lavastoviglie"
+      },
       "sensor_heatup_progress": {
         "name": "Avanzamento riscaldamento"
       },

--- a/custom_components/homeconnect_ws/translations/nl.json
+++ b/custom_components/homeconnect_ws/translations/nl.json
@@ -705,6 +705,9 @@
           "full": "Vol"
         }
       },
+      "sensor_machine_care_reminder": {
+        "name": "Machineonderhoud herinnering"
+      },
       "sensor_start_in": {
         "name": "Start over"
       },


### PR DESCRIPTION
Add sensor_machine_care_reminder entity exposing Dishcare.Dishwasher.Status.MachineCareReminder.RemainingProgramRuns as a numeric sensor showing wash cycles remaining before machine care is required. Tested on Neff dishwasher with Home Connect Local WS v1.0.5b10. Translations added for en, de, it, nl.