### PR TITLE
Add Pre-Treatment option for dishwashers

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/dishcare.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/dishcare.py
@@ -346,5 +346,10 @@ DISHCARE_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             entity="Dishcare.Dishwasher.Option.ExtraRinse",
             device_class=SwitchDeviceClass.SWITCH,
         ),
+        HCSwitchEntityDescription(
+            key="switch_pretreatment",
+            entity="Dishcare.Dishwasher.Option.Pretreatment",
+            device_class=SwitchDeviceClass.SWITCH,
+        ),
     ],
 }

--- a/custom_components/homeconnect_ws/icons.json
+++ b/custom_components/homeconnect_ws/icons.json
@@ -46,6 +46,9 @@
             "switch_extra_rinse": {
                 "default": "mdi:water-plus"
             },
+            "switch_pretreatment": {
+                "default": "mdi:pot-steam-outline"
+            },
             "switch_cup_warmer": {
                 "default": "mdi:heat-wave"
             }

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -208,6 +208,9 @@
       },
       "switch_extra_rinse": {
         "name": "Extra Rinse"
+      },
+      "switch_pretreatment": {
+        "name": "Pre-Treatment"
       }
     },
     "binary_sensor": {

--- a/custom_components/homeconnect_ws/translations/ru.json
+++ b/custom_components/homeconnect_ws/translations/ru.json
@@ -44,6 +44,9 @@
       "switch_intensiv_zone": {
         "name": "Интенсивная зона"
       },
+      "switch_pretreatment": {
+        "name": "Предварительное ополаскивание"
+      },
       "switch_vario_speed_plus": {
         "name": "VariospeedPlus"
       },


### PR DESCRIPTION
## What
Adds the `Dishcare.Dishwasher.Option.Pretreatment` option as a switch entity for dishwashers.

Bosch labels this feature **Pre-Treatment** (RU: «Предварительное ополаскивание»): heated pre-rinsing with a steam phase to improve cleaning performance.

Implemented analogously to the Extra Rinse option (#266):
- `entity_descriptions/dishcare.py`: `switch_pretreatment` → `Dishcare.Dishwasher.Option.Pretreatment`
- `translations/en.json` / `translations/ru.json`: display names
- `icons.json`: `mdi:pot-steam-outline`

## Tested
Verified on a Bosch SMV4HMX65Q — the switch appears and toggles correctly on the Intensiv 70 / Auto 2 / Eco 50 / Quick 65 programs.

## Notes
Option key confirmed against the device's DeviceDescription profile and the official Bosch instruction manual (which lists it under "Additional functions" as *Pre-Treatment*).