### PR TITLE
Add read-only binary sensors for dishwasher program options

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/dishcare.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/dishcare.py
@@ -20,6 +20,22 @@ from .descriptions_definitions import (
 DISHCARE_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
     "binary_sensor": [
         HCBinarySensorEntityDescription(
+            key="binary_sensor_intensiv_zone_active",
+            entity="Dishcare.Dishwasher.Option.IntensivZone",
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_half_load_active",
+            entity="Dishcare.Dishwasher.Option.HalfLoad",
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_hygiene_plus_active",
+            entity="Dishcare.Dishwasher.Option.HygienePlus",
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_pretreatment_active",
+            entity="Dishcare.Dishwasher.Option.Pretreatment",
+        ),
+        HCBinarySensorEntityDescription(
             key="binary_sensor_eco_dry_active",
             entity="Dishcare.Dishwasher.Status.EcoDryActive",
             entity_registry_enabled_default=False,

--- a/custom_components/homeconnect_ws/icons.json
+++ b/custom_components/homeconnect_ws/icons.json
@@ -10,7 +10,9 @@
             "switch_extra_dry_option": {
                 "default": "mdi:heat-wave"
             },
-            "switch_intensiv_zone": {},
+            "switch_intensiv_zone": {
+                "default": "mdi:arrow-decision"
+            },
             "switch_vario_speed_plus": {
                 "default": "mdi:timer-play-outline"
             },
@@ -53,6 +55,18 @@
         "binary_sensor": {
             "connection": {},
             "binary_sensor_door_state": {},
+            "binary_sensor_intensiv_zone_active": {
+                "default": "mdi:arrow-decision"
+            },
+            "binary_sensor_half_load_active": {
+                "default": "mdi:fraction-one-half"
+            },
+            "binary_sensor_hygiene_plus_active": {
+                "default": "mdi:thermometer-plus"
+            },
+            "binary_sensor_pretreatment_active": {
+                "default": "mdi:pot-steam-outline"
+            },
             "binary_sensor_eco_dry_active": {},
             "binary_sensor_aqua_stop": {
                 "default": "mdi:water-check-outline",

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -217,6 +217,18 @@
       "binary_sensor_door_state": {
         "name": "Door"
       },
+      "binary_sensor_intensiv_zone_active": {
+        "name": "Intensive Zone Active"
+      },
+      "binary_sensor_half_load_active": {
+        "name": "Half Load Active"
+      },
+      "binary_sensor_hygiene_plus_active": {
+        "name": "Hygiene Plus Active"
+      },
+      "binary_sensor_pretreatment_active": {
+        "name": "Pre-Treatment Active"
+      },
       "binary_sensor_eco_dry_active": {
         "name": "EcoDry Active"
       },

--- a/custom_components/homeconnect_ws/translations/ru.json
+++ b/custom_components/homeconnect_ws/translations/ru.json
@@ -166,6 +166,18 @@
       "binary_sensor_door_state": {
         "name": "Дверь"
       },
+      "binary_sensor_intensiv_zone_active": {
+        "name": "Интенсивная зона активна"
+      },
+      "binary_sensor_half_load_active": {
+        "name": "Половинная загрузка активна"
+      },
+      "binary_sensor_hygiene_plus_active": {
+        "name": "Гигиена+ активна"
+      },
+      "binary_sensor_pretreatment_active": {
+        "name": "Замачивание активно"
+      },
       "binary_sensor_eco_dry_active": {
         "name": "EcoDry активен"
       },


### PR DESCRIPTION
## What

Adds read-only `binary_sensor` entities mirroring four dishwasher program options: **IntensivZone**, **HalfLoad**, **HygienePlus**, **Pretreatment**.

## Why

While a program is running, the appliance sets these options to `access: read` (you can't change them mid-cycle). Since the option switches use `available_access = (READ_WRITE, WRITE_ONLY)`, they become `unavailable` during the run and their state is hidden — so a dashboard can't show which options the running cycle actually uses.

The new binary sensors have `available_access` including `READ`, so they stay available during the cycle and expose the active option state. The switches remain the write path while the appliance is idle.

Verified on a real Bosch SMV4HMX65Q: during a running Auto2 cycle with Half Load enabled, `switch.*_half_load` is `unavailable` while the new `binary_sensor.*_half_load_active` correctly reports `on`.

## Changes

- `dishcare.py`: 4 `HCBinarySensorEntityDescription` (`*_active`).
- `en.json` / `ru.json`: names.
- `icons.json`: icons matching the corresponding switches (also filled the previously-empty `switch_intensiv_zone` icon).