### PR TITLE
light: support appliances that drop light attributes while off

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/refrigeration.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/refrigeration.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.number import NumberDeviceClass, NumberMode
 from homeassistant.components.sensor import SensorDeviceClass
@@ -17,6 +19,49 @@ from .descriptions_definitions import (
     HCSwitchEntityDescription,
     _EntityDescriptionsDefinitionsType,
 )
+
+if TYPE_CHECKING:
+    from homeconnect_websocket import HomeAppliance
+
+
+def generate_internal_light(appliance: HomeAppliance) -> HCLightEntityDescription | None:
+    """Get internal light description."""
+    if "Refrigeration.Common.Setting.Light.Internal.Power" not in appliance.entities:
+        return None
+
+    if "Refrigeration.Common.Setting.Light.Internal.Brightness" in appliance.entities:
+        return HCLightEntityDescription(
+            key="light_internal",
+            entity="Refrigeration.Common.Setting.Light.Internal.Power",
+            brightness_entity="Refrigeration.Common.Setting.Light.Internal.Brightness",
+        )
+
+    return HCLightEntityDescription(
+        key="light_internal",
+        entity="Refrigeration.Common.Setting.Light.Internal.Power",
+    )
+
+
+def generate_internal_light_brightness(
+    appliance: HomeAppliance,
+) -> HCNumberEntityDescription | None:
+    """Get internal light brightness description."""
+    if "Refrigeration.Common.Setting.Light.Internal.Brightness" not in appliance.entities:
+        return None
+
+    # The light entity already exposes brightness, so this would be a
+    # second control for the same setting.
+    owned_by_light = "Refrigeration.Common.Setting.Light.Internal.Power" in appliance.entities
+
+    return HCNumberEntityDescription(
+        key="number_light_internal_brightness",
+        entity="Refrigeration.Common.Setting.Light.Internal.Brightness",
+        native_unit_of_measurement=PERCENTAGE,
+        mode=NumberMode.AUTO,
+        step=1,
+        entity_registry_enabled_default=not owned_by_light,
+    )
+
 
 REFRIGERATION_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
     "binary_sensor": [
@@ -256,13 +301,7 @@ REFRIGERATION_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             mode=NumberMode.AUTO,
             step=1,
         ),
-        HCNumberEntityDescription(
-            key="number_light_internal_brightness",
-            entity="Refrigeration.Common.Setting.Light.Internal.Brightness",
-            native_unit_of_measurement=PERCENTAGE,
-            mode=NumberMode.AUTO,
-            step=1,
-        ),
+        generate_internal_light_brightness,
     ],
     "switch": [
         HCSwitchEntityDescription(
@@ -389,10 +428,7 @@ REFRIGERATION_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
         ),
     ],
     "light": [
-        HCLightEntityDescription(
-            key="light_internal",
-            entity="Refrigeration.Common.Setting.Light.Internal.Power",
-        ),
+        generate_internal_light,
         HCLightEntityDescription(
             key="light_logo",
             entity="Refrigeration.Common.Setting.Light.Logo.Power",

--- a/custom_components/homeconnect_ws/light.py
+++ b/custom_components/homeconnect_ws/light.py
@@ -24,7 +24,7 @@ from homeconnect_websocket.message import Action
 from homeconnect_websocket.message import Message as HC_Message
 
 from .entity import HCEntity
-from .helpers import create_entities, entity_is_available, error_decorator
+from .helpers import create_entities, error_decorator
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -105,22 +105,9 @@ class HCLight(HCEntity, LightEntity):
             self._attr_supported_color_modes = {ColorMode.ONOFF}
             self._attr_color_mode = ColorMode.ONOFF
 
-    @property
-    def available(self) -> bool:
-        available = super().available
-        if self._brightness_entity:
-            available &= entity_is_available(
-                self._brightness_entity, self.entity_description.available_access
-            )
-        if self._color_temperature_entity:
-            available &= entity_is_available(
-                self._color_temperature_entity, self.entity_description.available_access
-            )
-        if self._color_entity:
-            available &= entity_is_available(
-                self._color_entity, self.entity_description.available_access
-            )
-        return available
+    # Availability deliberately follows the power entity alone. Appliances
+    # mark attribute entities such as brightness unavailable while the light
+    # is off, and losing an attribute must not remove the on/off control.
 
     @property
     def is_on(self) -> bool | None:
@@ -128,16 +115,19 @@ class HCLight(HCEntity, LightEntity):
 
     @property
     def brightness(self) -> int | None:
-        if self._color_entity is not None:
+        if self._color_entity is not None and self._color_entity.value is not None:
             rgb = rgb_hex_to_rgb_list(self._color_entity.value.strip("#"))
             return max(rgb)
-        if self._brightness_entity is not None:
+        if self._brightness_entity is not None and self._brightness_entity.value is not None:
             return value_to_brightness((1, 100), self._brightness_entity.value)
         return None
 
     @property
     def color_temp_kelvin(self) -> int | None:
-        if self._color_temperature_entity is not None:
+        if (
+            self._color_temperature_entity is not None
+            and self._color_temperature_entity.value is not None
+        ):
             if self._color_temp_inverted:
                 return scale_ranged_value_to_int_range(
                     (101, 0),
@@ -154,7 +144,7 @@ class HCLight(HCEntity, LightEntity):
 
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:
-        if self._color_entity is not None:
+        if self._color_entity is not None and self._color_entity.value is not None:
             rgb = rgb_hex_to_rgb_list(self._color_entity.value.strip("#"))
             return match_max_scale((255,), rgb)
         return None

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 from custom_components.homeconnect_ws import entity_descriptions
 from custom_components.homeconnect_ws.entity_descriptions import (
     HCBinarySensorEntityDescription,
+    HCLightEntityDescription,
     HCSelectEntityDescription,
     HCSensorEntityDescription,
     HCSwitchEntityDescription,
@@ -15,6 +16,10 @@ from custom_components.homeconnect_ws.entity_descriptions import (
 from custom_components.homeconnect_ws.entity_descriptions.common import (
     generate_power_switch,
     generate_program,
+)
+from custom_components.homeconnect_ws.entity_descriptions.refrigeration import (
+    generate_internal_light,
+    generate_internal_light_brightness,
 )
 from custom_components.homeconnect_ws.helpers import merge_dicts
 from homeassistant.components.sensor import SensorDeviceClass
@@ -216,3 +221,64 @@ async def test_program(mock_homeconnect_appliance: MockApplianceType) -> None:
     )
 
     appliance = await mock_homeconnect_appliance(description={})
+
+
+INTERNAL_LIGHT = DeviceDescription(
+    setting=[
+        EntityDescription(
+            uid=0x5001,
+            name="Refrigeration.Common.Setting.Light.Internal.Power",
+            access=Access.READ_WRITE,
+            available=True,
+        ),
+        EntityDescription(
+            uid=0x5002,
+            name="Refrigeration.Common.Setting.Light.Internal.Brightness",
+            access=Access.READ_WRITE,
+            available=True,
+            max=100,
+            min=0,
+        ),
+    ]
+)
+
+
+async def test_internal_light(mock_homeconnect_appliance: MockApplianceType) -> None:
+    """Test dynamic internal light."""
+    # Power + Brightness
+    appliance = await mock_homeconnect_appliance(description=INTERNAL_LIGHT)
+    assert generate_internal_light(appliance) == HCLightEntityDescription(
+        key="light_internal",
+        entity="Refrigeration.Common.Setting.Light.Internal.Power",
+        brightness_entity="Refrigeration.Common.Setting.Light.Internal.Brightness",
+    )
+
+    # Power only
+    power_only = DeviceDescription(setting=[INTERNAL_LIGHT["setting"][0]])
+    appliance = await mock_homeconnect_appliance(description=power_only)
+    assert generate_internal_light(appliance) == HCLightEntityDescription(
+        key="light_internal",
+        entity="Refrigeration.Common.Setting.Light.Internal.Power",
+    )
+
+    # No internal light
+    appliance = await mock_homeconnect_appliance(description={})
+    assert generate_internal_light(appliance) is None
+
+
+async def test_internal_light_brightness(mock_homeconnect_appliance: MockApplianceType) -> None:
+    """Test the brightness number defers to the light entity."""
+    # Light entity owns brightness, so the number is opt-in
+    appliance = await mock_homeconnect_appliance(description=INTERNAL_LIGHT)
+    description = generate_internal_light_brightness(appliance)
+    assert description.entity_registry_enabled_default is False
+
+    # No light entity to own it, so the number is the only control
+    brightness_only = DeviceDescription(setting=[INTERNAL_LIGHT["setting"][1]])
+    appliance = await mock_homeconnect_appliance(description=brightness_only)
+    description = generate_internal_light_brightness(appliance)
+    assert description.entity_registry_enabled_default is True
+
+    # No brightness at all
+    appliance = await mock_homeconnect_appliance(description={})
+    assert generate_internal_light_brightness(appliance) is None

--- a/tests/test_light.py
+++ b/tests/test_light.py
@@ -710,3 +710,60 @@ async def test_set_color(
         )
     )
     mock_appliance.session.send_sync.reset_mock()
+
+
+async def test_available_when_brightness_unavailable(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,
+) -> None:
+    """Test the light stays controllable when only brightness goes unavailable."""
+    assert await setup_config_entry(hass, CONFIG_ENTRIES[0])
+    await mock_appliance.entities["Test.Lighting"].update({"value": False})
+    await hass.async_block_till_done()
+
+    # Appliances mark brightness unavailable while the light is off; the light
+    # itself must stay available so it can be switched back on.
+    await mock_appliance.entities["Test.LightingBrightness"].update({"available": False})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.fake_brand_homeappliance_light_2")
+    assert state
+    assert state.state == STATE_OFF
+
+
+async def test_turn_on_when_brightness_has_no_value(
+    hass: HomeAssistant,
+    mock_appliance: MockAppliance,
+    patch_entity_description: None,
+) -> None:
+    """Test turning on while the appliance reports no brightness value."""
+    assert await setup_config_entry(hass, CONFIG_ENTRIES[0])
+    # The appliance drops the brightness value while the light is off. The
+    # entity cannot be updated to None, so clear it the way a never-received
+    # value leaves it.
+    await mock_appliance.entities["Test.Lighting"].update({"value": False})
+    mock_appliance.entities["Test.LightingBrightness"]._value = None
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.fake_brand_homeappliance_light_2")
+    assert state
+    assert state.attributes[ATTR_BRIGHTNESS] is None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {
+            ATTR_ENTITY_ID: "light.fake_brand_homeappliance_light_2",
+            ATTR_BRIGHTNESS_PCT: 100,
+        },
+        blocking=True,
+    )
+    mock_appliance.session.send_sync.assert_awaited_once_with(
+        Message(
+            resource="/ro/values",
+            action=Action.POST,
+            data=[{"uid": 109, "value": 100}, {"uid": 108, "value": True}],
+        )
+    )
+    mock_appliance.session.send_sync.reset_mock()


### PR DESCRIPTION
## Problem

`Refrigeration.Common.Setting.Light.Internal` is exposed by the appliance as a `Power` setting plus a `Brightness` setting, but only the `Power` half was wired into the light entity. The internal light was on/off only, and brightness was reachable solely through a separate `number` entity.

Wiring brightness in as `brightness_entity` surfaced two latent bugs in `light.py`. On a Bosch B36CL80ENS, **while the light is off the appliance reports `Brightness` as `available: false` and `value: None`**:

**1. An off light became permanently unavailable.** `HCLight.available` AND-ed in the brightness, colour-temperature and colour entities. Light off → brightness unavailable → the whole light entity unavailable → no way to switch it back on from Home Assistant.

**2. Every `turn_on` raised `TypeError`.** `brightness` fed the `None` straight into `value_to_brightness`, and `async_turn_on` evaluates `self.brightness` eagerly as the `kwargs.get` default even when a brightness was passed:

```python
brightness = kwargs.get(ATTR_BRIGHTNESS, self.brightness)   # always evaluated
```

```
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
  File "custom_components/homeconnect_ws/light.py", line 156, in async_turn_on
  File "custom_components/homeconnect_ws/light.py", line 122, in brightness
```

Together these meant one toggle off left a light that could only be re-enabled at the appliance's own panel.

## Changes

- `HCLight.available` follows the power entity alone. An attribute entity dropping out should not remove the on/off control.
- `brightness`, `color_temp_kelvin` and `rgb_color` return `None` when the appliance has no value for the underlying entity.
- `light_internal` is built by a generator, following `generate_hood_light`, so appliances without the `Brightness` feature still get a plain on/off light.
- The standalone brightness `number` ships disabled by default when a light entity claims brightness — matching how `switch_refrigeration_light_internal` is already handled.

## Testing

Two regression tests, both confirmed to fail against the previous behaviour:

- `test_available_when_brightness_unavailable` — fails with `assert 'unavailable' == 'off'`
- `test_turn_on_when_brightness_has_no_value` — fails with the exact production `TypeError`

Plus `test_internal_light` / `test_internal_light_brightness` for the generators. Full suite green.

Verified on real hardware (Bosch B36CL80ENS, HA 2026.8.2): `off → turn_on 60% → on`, then 100/70/40/15/50% in sequence with the power setting never disturbed.
