### PR TITLE
refrigeration: add features the description tables were missing

### DIFF
--- a/custom_components/homeconnect_ws/entity_descriptions/refrigeration.py
+++ b/custom_components/homeconnect_ws/entity_descriptions/refrigeration.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.number import NumberDeviceClass, NumberMode
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
 
 from .descriptions_definitions import (
     HCBinarySensorEntityDescription,
+    HCButtonEntityDescription,
     HCLightEntityDescription,
     HCNumberEntityDescription,
     HCSelectEntityDescription,
@@ -162,6 +163,74 @@ REFRIGERATION_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             value_on={"Present", "Confirmed"},
             value_off={"Off"},
         ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_freezer_appliance_error",
+            entity="Refrigeration.Common.Event.ApplianceError",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            value_on={"Present", "Confirmed"},
+            value_off={"Off"},
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_freezer_low_voltage",
+            entity="Refrigeration.Common.Event.LowVoltageHint",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            value_on={"Present", "Confirmed"},
+            value_off={"Off"},
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_temperature_alarm_chiller_common",
+            entity="Refrigeration.Common.Event.ChillerCommon.TemperatureAlarm",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            value_on={"Present", "Confirmed"},
+            value_off={"Off"},
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_ice_hopper_full",
+            entity="Refrigeration.Common.Status.Dispenser.IceHopperFull",
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_water_filter_almost_full",
+            entity="Refrigeration.Common.Event.Dispenser.WaterFilterAlmostFull",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            value_on={"Present", "Confirmed"},
+            value_off={"Off"},
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_ice_expired",
+            entity="Refrigeration.Common.Event.Dispenser.IceExpired",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            value_on={"Present", "Confirmed"},
+            value_off={"Off"},
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_water_expired",
+            entity="Refrigeration.Common.Event.WaterExpired",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            value_on={"Present", "Confirmed"},
+            value_off={"Off"},
+        ),
+        HCBinarySensorEntityDescription(
+            key="binary_sensor_party_mode_empty_ice_hopper",
+            entity="Refrigeration.Common.Event.Dispenser.PartyModeEmptyIceHopper",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            entity_registry_enabled_default=False,
+            value_on={"Present", "Confirmed"},
+            value_off={"Off"},
+        ),
+    ],
+    "button": [
+        HCButtonEntityDescription(
+            key="button_water_filter_reset",
+            entity="Refrigeration.Common.Command.Dispenser.WaterFilterReset",
+            entity_category=EntityCategory.CONFIG,
+        ),
     ],
     "sensor": [
         HCSensorEntityDescription(
@@ -175,6 +244,12 @@ REFRIGERATION_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
             entity="Refrigeration.Common.Status.TemperatureAmbient",
             device_class=SensorDeviceClass.TEMPERATURE,
             native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ),
+        HCSensorEntityDescription(
+            key="sensor_water_filter_saturation",
+            entity="Refrigeration.Common.Status.Dispenser.WaterFilterSaturation",
+            native_unit_of_measurement=PERCENTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
         ),
         HCSensorEntityDescription(
             key="sensor_temperature_memory_freezer",
@@ -308,6 +383,11 @@ REFRIGERATION_ENTITY_DESCRIPTIONS: _EntityDescriptionsDefinitionsType = {
         HCSwitchEntityDescription(
             key="switch_refrigerator_dispenser_enabled",
             entity="Refrigeration.Common.Setting.Dispenser.Enabled",
+            device_class=SwitchDeviceClass.SWITCH,
+        ),
+        HCSwitchEntityDescription(
+            key="switch_refrigerator_dispenser_party_mode",
+            entity="Refrigeration.Common.Setting.Dispenser.PartyMode",
             device_class=SwitchDeviceClass.SWITCH,
         ),
         HCSwitchEntityDescription(

--- a/custom_components/homeconnect_ws/icons.json
+++ b/custom_components/homeconnect_ws/icons.json
@@ -53,6 +53,9 @@
             },
             "switch_cup_warmer": {
                 "default": "mdi:heat-wave"
+            },
+            "switch_refrigerator_dispenser_party_mode": {
+                "default": "mdi:party-popper"
             }
         },
         "binary_sensor": {
@@ -100,6 +103,66 @@
                 "state": {
                     "off": "mdi:snowflake-off",
                     "on": "mdi:snowflake-melt"
+                }
+            },
+            "binary_sensor_temperature_alarm_freezer": {
+                "default": "mdi:thermometer",
+                "state": {
+                    "on": "mdi:thermometer-alert"
+                }
+            },
+            "binary_sensor_temperature_alarm_chiller_common": {
+                "default": "mdi:thermometer",
+                "state": {
+                    "on": "mdi:thermometer-alert"
+                }
+            },
+            "binary_sensor_freezer_appliance_error": {
+                "default": "mdi:fridge-outline",
+                "state": {
+                    "on": "mdi:fridge-alert-outline"
+                }
+            },
+            "binary_sensor_freezer_low_voltage": {
+                "default": "mdi:flash-outline",
+                "state": {
+                    "on": "mdi:flash-alert-outline"
+                }
+            },
+            "binary_sensor_ice_hopper_full": {
+                "default": "mdi:snowflake",
+                "state": {
+                    "on": "mdi:snowflake-check"
+                }
+            },
+            "binary_sensor_ice_expired": {
+                "default": "mdi:snowflake",
+                "state": {
+                    "on": "mdi:snowflake-alert"
+                }
+            },
+            "binary_sensor_party_mode_empty_ice_hopper": {
+                "default": "mdi:party-popper",
+                "state": {
+                    "on": "mdi:snowflake-off"
+                }
+            },
+            "binary_sensor_water_filter_full": {
+                "default": "mdi:water-check-outline",
+                "state": {
+                    "on": "mdi:water-alert-outline"
+                }
+            },
+            "binary_sensor_water_filter_almost_full": {
+                "default": "mdi:water-check-outline",
+                "state": {
+                    "on": "mdi:water-percent-alert"
+                }
+            },
+            "binary_sensor_water_expired": {
+                "default": "mdi:water-outline",
+                "state": {
+                    "on": "mdi:water-alert"
                 }
             }
         },
@@ -191,6 +254,9 @@
             },
             "sensor_carbon_filter_saturation": {
                 "default": "mdi:air-filter"
+            },
+            "sensor_water_filter_saturation": {
+                "default": "mdi:water-percent"
             },
             "sensor_count_ristretto_espresso": {
                 "default": "mdi:coffee"
@@ -320,6 +386,9 @@
                 "default": "mdi:restore"
             },
             "button_hood_regenerative_carbon_filter_lifetime_reset": {
+                "default": "mdi:restore"
+            },
+            "button_water_filter_reset": {
                 "default": "mdi:restore"
             }
         },

--- a/custom_components/homeconnect_ws/translations/en.json
+++ b/custom_components/homeconnect_ws/translations/en.json
@@ -189,6 +189,9 @@
       "switch_refrigerator_dispenser_enabled": {
         "name": "Dispenser"
       },
+      "switch_refrigerator_dispenser_party_mode": {
+        "name": "Dispenser Party mode"
+      },
       "switch_refrigerator_door_assistant_freezer": {
         "name": "Freezer Door Assistant"
       },
@@ -390,6 +393,12 @@
       "binary_sensor_idos_unit_defect": {
         "name": "i-DOS Defect"
       },
+      "binary_sensor_idos_open_tray": {
+        "name": "i-DOS Open Tray"
+      },
+      "binary_sensor_release_rinse_hold_pending": {
+        "name": "Release Rinse Hold Pending"
+      },
       "binary_sensor_pump_error": {
         "name": "Pump Error"
       },
@@ -419,6 +428,24 @@
       },
       "binary_sensor_water_filter_full": {
         "name": "Water filter full"
+      },
+      "binary_sensor_water_filter_almost_full": {
+        "name": "Water filter almost full"
+      },
+      "binary_sensor_ice_hopper_full": {
+        "name": "Ice hopper full"
+      },
+      "binary_sensor_ice_expired": {
+        "name": "Ice expired"
+      },
+      "binary_sensor_water_expired": {
+        "name": "Water expired"
+      },
+      "binary_sensor_party_mode_empty_ice_hopper": {
+        "name": "Party mode ice hopper empty"
+      },
+      "binary_sensor_temperature_alarm_chiller_common": {
+        "name": "Temperature alarm Chiller"
       },
       "binary_sensor_freezer_appliance_error": {
         "name": "Appliance Error"
@@ -1566,6 +1593,9 @@
       },
       "sensor_laundry_load_recommendation": {
         "name": "Load Recommendation"
+      },
+      "sensor_water_filter_saturation": {
+        "name": "Water filter saturation"
       },
       "sensor_temperature_memory_freezer": {
         "name": "Memory Temperature Freezer"
@@ -3387,6 +3417,9 @@
           "fanstage03": "3"
         }
       },
+      "select_hob_ventilation": {
+        "name": "Ventilation"
+      },
       "select_hob_delaye_shutoff_stage": {
         "name": "Delayed ShutOff Stage",
         "state": {
@@ -3439,6 +3472,9 @@
       },
       "button_hood_regenerative_carbon_filter_lifetime_reset": {
         "name": "Regenerative Carbon filter lifetime reset"
+      },
+      "button_water_filter_reset": {
+        "name": "Water filter reset"
       }
     },
     "number": {
@@ -3495,6 +3531,9 @@
       },
       "number_start_in": {
         "name": "Start in"
+      },
+      "number_finish_in": {
+        "name": "Finish in"
       },
       "number_setting_alarm_clock": {
         "name": "Alarm Clock"

--- a/tests/test_entity_descriptions.py
+++ b/tests/test_entity_descriptions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
@@ -216,3 +218,41 @@ async def test_program(mock_homeconnect_appliance: MockApplianceType) -> None:
     )
 
     appliance = await mock_homeconnect_appliance(description={})
+
+
+TRANSLATION_DOMAINS = {
+    "active_program": "sensor",
+    "binary_sensor": "binary_sensor",
+    "button": "button",
+    "event_sensor": "sensor",
+    "fan": "fan",
+    "light": "light",
+    "number": "number",
+    "program": "select",
+    "select": "select",
+    "sensor": "sensor",
+    "start_button": "button",
+    "switch": "switch",
+    "wifi": "sensor",
+}
+
+
+def test_descriptions_have_english_name() -> None:
+    """Test every entity description resolves to a name in en.json."""
+    translations = json.loads(
+        Path("custom_components/homeconnect_ws/translations/en.json").read_text(encoding="utf-8")
+    )["entity"]
+
+    missing = []
+    for description_type, descriptions in entity_descriptions.get_all_entity_description().items():
+        if description_type == "dynamic":
+            continue
+        domain = TRANSLATION_DOMAINS[description_type]
+        for description in descriptions:
+            if callable(description):
+                continue
+            key = description.translation_key or description.key
+            if key not in translations.get(domain, {}):
+                missing.append(f"{domain}.{key}")
+
+    assert sorted(set(missing)) == []


### PR DESCRIPTION
My Bosch B36CL80ENS fridge/freezer profile exposes 34 features that aren't in the table. A notable subset are features that *are* already described, but only for the `Refrigeration.FridgeFreezer.*` namespace, while this appliance speaks `Refrigeration.Common.*`.

## Changes

- ice hopper full, ice expired, water expired
- water filter saturation sensor (%) and water filter reset button
- water filter almost full event
- dispenser party mode and its empty-hopper event
- the `Refrigeration.Common.*` twins of `ApplianceError`, `LowVoltageHint` and `ChillerCommon.TemperatureAlarm`, previously mapped only for `Refrigeration.FridgeFreezer.*`

The water filter saturation percentage is the one I'd most want reviewed for usefulness — upstream currently exposes only the binary "filter full" event, so there's no way to watch it climb and plan a replacement.

**No existing entity is changed.** The only removed line in the diff is an import.

## Entity categories

Alarms and the dispenser expiry hints are diagnostic, the water filter reset is config, and the party-mode empty-hopper event is disabled by default since it is only meaningful during party mode.

## Testing

Adds `test_descriptions_have_english_name`, asserting every entity description resolves to a name in `en.json` — entity names come from there keyed by `translation_key` falling back to `key`, and nothing checked that the key actually resolved, so a description added without a matching string silently produced an entity named after its object_id. It turned up four existing descriptions already in that state, whose names are added here: `idos_open_tray`, `release_rinse_hold_pending`, `number_finish_in`, `hob_ventilation`.

Full suite green. Verified on real hardware (Bosch B36CL80ENS, HA 2026.8.2): clean setup, no errors.

## Related

`BSH.Common` entity descriptions from the same profile are held back for a separate PR to keep this one to one namespace.
