### PR TITLE
Fix version 2 config entry setup: profile file write and missing appliance info

### DIFF
--- a/custom_components/homeconnect_ws/__init__.py
+++ b/custom_components/homeconnect_ws/__init__.py
@@ -197,6 +197,10 @@ async def async_setup_entry(
         _LOGGER.debug("Setting up %s", config_entry.data[CONF_APPLIANCE_INFO].get("model"))
         storage_dir = Path(hass.config.path(STORAGE_DIR, DOMAIN))
         description = await hass.async_add_executor_job(load_description, storage_dir, config_entry)
+        description["info"] = {
+            **description.get("info", {}),
+            **config_entry.data[CONF_APPLIANCE_INFO],
+        }
 
     coordinator = HomeConnectCoordinator(hass, config_entry, description)
 

--- a/custom_components/homeconnect_ws/config_flow.py
+++ b/custom_components/homeconnect_ws/config_flow.py
@@ -115,7 +115,9 @@ def process_profile_file(hass: HomeAssistant, uploaded_file_id: str) -> dict[str
 
 def write_file(storage_dir: Path, name: str, file: bytes) -> None:
     """Write file."""
-    with (storage_dir / name).open("w") as f:
+    file_path = storage_dir / name
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    with file_path.open("wb") as f:
         f.write(file)
 
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -37,6 +37,8 @@ from .const import (
 from .const import MOCK_CONFIG_DATA_1 as MOCK_CONFIG_DATA
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pytest
     from homeassistant.core import HomeAssistant
 
@@ -775,3 +777,15 @@ async def test_process_profile(
     }
 
     mock_process_uploaded_file.assert_called_with(hass, UPLOADED_FILE)
+
+
+async def test_write_file(tmp_path: Path) -> None:
+    """Test write_file writes bytes and creates the missing storage directory."""
+    storage_dir = tmp_path / "homeconnect_ws"
+    name = f"{MOCK_TLS_DEVICE_ID}/DeviceDescription.xml"
+
+    assert not storage_dir.exists()
+
+    config_flow.write_file(storage_dir, name, b"TLS_DeviceDescription")
+
+    assert (storage_dir / name).read_bytes() == b"TLS_DeviceDescription"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -77,3 +77,41 @@ async def test_remove_entry(
     if config_entry.version == 1:
         unlink_mock.assert_not_called()
         rmdir_mock.assert_not_called()
+
+
+async def test_setup_entry_merges_appliance_info(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test stored appliance info is merged into the description loaded from disk."""
+    # parse_device_description only emits brand/type/model/version/revision, so a
+    # description loaded from disk has no "vib". It has to come from the appliance
+    # info captured during the config flow and stored on the entry.
+    config_entry = CONFIG_ENTRIES[1]
+    assert config_entry.version == 2
+
+    parsed_description = {
+        **DEVICE_DESCRIPTION,
+        "info": {
+            "brand": "Fake_Brand",
+            "type": "HomeAppliance",
+            "model": "Fake_model",
+            "version": 1,
+            "revision": 2,
+        },
+    }
+
+    appliance = MockAppliance(DEVICE_DESCRIPTION, "host", "mock_app", "mock_app_id", "PSK_KEY")
+    appliance_mock = Mock(return_value=appliance)
+    monkeypatch.setattr(homeconnect_ws.coordinator, "HomeAppliance", appliance_mock)
+    monkeypatch.setattr(homeconnect_ws, "load_description", Mock(return_value=parsed_description))
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    description = appliance_mock.call_args.kwargs["description"]
+    assert description["info"]["vib"] == "Fake_vib"
+    assert description["info"]["model"] == "Fake_model"


### PR DESCRIPTION
Adding an appliance on `main` currently fails for me at two consecutive points. Both are in the version 2 config-entry path, and the second is only reachable once the first is fixed, so I've put them in one PR as two separate commits.

Reproduced on HA Core 2026.8.3 (HA OS 18.2) with `homeconnect_ws` at `main` (1.0.5b10), adding a Bosch KBN96VSE0 fridge-freezer discovered over zeroconf.

---

### 1. `write_file` never creates its directory, and writes bytes in text mode

`write_file` is called with `name = f"{device_id}/DeviceDescription.xml"`, so the directory that has to exist is `.storage/homeconnect_ws/<device_id>/`. Nothing in the integration ever creates it — there's no `mkdir` anywhere in the codebase — and `remove_files` actively `rmdir()`s it when an entry is removed. So it's missing on a first-ever setup, and missing again after the last entry is removed.

That surfaces as `FileNotFoundError`, which the caller catches as `OSError` and turns into the `failed_to_write_profile_file` abort — the UI shows **"Profile File could not be stored"** and no appliance can be added.

There's a second defect in the same three lines. The payload is `bytes` (`_process_zip_file` builds it with `ZipFile.open(...).read()`, and `ProfileFileEntry` types it as `bytes`), but the target is opened in text mode. Once the directory exists, that raises:

```
TypeError: write() argument must be str, not bytes
```

which is **not** an `OSError`, so it escapes the caller's `except OSError` and surfaces as an unhandled "Unknown error occurred" instead of the intended abort.

Fixed by creating `(storage_dir / name).parent` and opening in binary mode.

### 2. `KeyError: 'vib'` on setup

With the profile file written, setup then fails:

```
File "custom_components/homeconnect_ws/coordinator.py", line 48, in __init__
    name=description["info"]["vib"],
KeyError: 'vib'
```

Version 2 entries load the description from disk and run it through `parse_device_description`. That parser builds `info` from the DDF `<description>` element, and `parse_info` only ever emits `brand`, `type`, `model`, `version` and `revision`. There is no `vib` in the DDF XML at all, so `description["info"]["vib"]` can never succeed on this path. Version 1 entries are unaffected, because their inlined description carries the rich info dict captured during the config flow.

The rich info is already stored on the entry — `config_flow` connects to the appliance and saves what it reports as `CONF_APPLIANCE_INFO` (that dict does contain `vib`). It just isn't merged back into the description at setup. Besides the crash, this also meant the device registry lost `vib`, `mac`, `swVersion` and `hwVersion`, since those are read via `appliance.info.get(...)` and silently became `None`.

Fixed by merging the stored appliance info over the parsed info on setup.

---

### Why the existing tests didn't catch either

Both are masked by the fixtures rather than by missing coverage:

- Every config-flow test replaces `write_file` with `MagicMock(return_value=None)`, so neither the missing directory nor the text-mode write is ever executed.
- `test_init` mocks `load_description` to return the `DEVICE_DESCRIPTION` fixture, whose `info` **is** `MOCK_APPLIANCE_INFO` and therefore already contains `vib` — a shape the real parser never produces. The v2 path is exercised, but only with data that hides the bug.

Each commit adds a regression test that fails on current `main` with the same error seen in production and passes with the fix. Full suite is green (84 passed), `ruff check` and `ruff format --check` are clean.

### Verified

Both appliances now load on a real install: a Bosch HRG7784B1 oven (pre-existing v1 entry) and the KBN96VSE0 fridge-freezer (new v2 entry), the latter via the zeroconf discovery flow with a two-appliance profile ZIP.

### Unrelated nit

`tests/const.py` has `CONF_DESCRIPTION_FILENAME` and `CONF_FEATURE_FILENAME` swapped in `MOCK_CONFIG_DATA_2` (description points at `FeatureMapping.xml` and vice versa). It's inert today because `load_description` is mocked, so I've left it alone — happy to fix it here or separately if you'd like.
